### PR TITLE
Expose Tensorflow Run Options

### DIFF
--- a/setup.py~
+++ b/setup.py~
@@ -2,9 +2,9 @@ from setuptools import setup
 
 setup(
     name='keras-tcn',
-    version='2.6.7.1',
+    version='2.6.7',
     description='Keras TCN',
-    author='Philippe Remy + Vincent D',
+    author='Philippe Remy',
     license='MIT',
     long_description_content_type='text/markdown',
     long_description=open('README.md').read(),

--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -155,7 +155,9 @@ def compiled_tcn(
         dropout_rate=0.05,  # type: float
         name='tcn',  # type: str,
         opt='adam',
-        lr=0.002):
+        lr=0.002,
+        options=None,
+        run_metadata=None):
     # type: (...) -> keras.Model
     """Creates a compiled TCN model for a given task (i.e. regression or classification).
     Classification uses a sparse categorical loss. Please input class ids and not one-hot encodings.
@@ -228,14 +230,21 @@ def compiled_tcn(
         model.compile(
             get_opt(),
             loss='sparse_categorical_crossentropy',
-            metrics=[accuracy])
+            metrics=[accuracy],
+            options=options,
+            run_metadata=run_metadata)
     else:
         # regression
         x = Dense(1)(x)
         x = Activation('linear')(x)
         output_layer = x
         model = Model(input_layer, output_layer)
-        model.compile(get_opt(), loss='mean_squared_error')
+        model.compile(
+            get_opt(),
+            loss='mean_squared_error',
+            options=options,
+            run_metadata=run_metadata)
+
     print(f'model.x = {input_layer.shape}')
     print(f'model.y = {output_layer.shape}')
     return model

--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -174,7 +174,7 @@ def compiled_tcn(num_feat,  # type: int
     # --- Vincent Added to deal with reshaping input ---
     total_input = max_len*num_feat          # max_len~wind size and num_feat~selected columns
     input_layer = Input(shape=(total_input, ))
-    reshape_layer = Reshape((max_len, num_feat, 1), input_shape=(total_input, ))(input_layer)
+    reshape_layer = Reshape((max_len, num_feat), input_shape=(total_input, ))(input_layer)
 
     # --- Vincent Stopped breaking stuff here ---
 

--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -173,7 +173,7 @@ def compiled_tcn(num_feat,  # type: int
 
     # --- Vincent Added to deal with reshaping input ---
     total_input = max_len*num_feat          # max_len~wind size and num_feat~selected columns
-    input_layer = Input(shape(total_input, ))
+    input_layer = Input(shape=(total_input, ))
     reshape_layer = Reshape((max_len, num_feat, 1), input_shape=(total_input, ))(input_layer)
 
     # --- Vincent Stopped breaking stuff here ---

--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -7,6 +7,7 @@ from keras.engine.topology import Layer
 from keras.layers import Activation, Lambda
 from keras.layers import Conv1D, SpatialDropout1D
 from keras.layers import Convolution1D, Dense
+from keras.layers import Reshape # Vincent Added
 from keras.models import Input, Model
 
 
@@ -168,10 +169,16 @@ def compiled_tcn(num_feat,  # type: int
 
     dilations = process_dilations(dilations)
 
-    input_layer = Input(shape=(max_len, num_feat))
+    # input_layer = Input(shape=(max_len, num_feat))
+    # --- Vincent Added to deal with reshaping input ---
+    total_input = max_len*num_feat          # max_len~wind size and num_feat~selected columns
+    input_layer = Input(shape(total_input, ))
+    reshape_layer = Reshape((max_len, num_feat, 1), input_shape=(total_input, ))(input_layer)
+
+    # --- Vincent Stopped breaking stuff here ---
 
     x = TCN(nb_filters, kernel_size, nb_stacks, dilations, padding,
-            use_skip_connections, dropout_rate, return_sequences, name)(input_layer)
+            use_skip_connections, dropout_rate, return_sequences, name)(reshape_layer)
 
     print('x.shape=', x.shape)
 

--- a/tcn/tcn.py~
+++ b/tcn/tcn.py~
@@ -170,6 +170,7 @@ def compiled_tcn(num_feat,  # type: int
     dilations = process_dilations(dilations)
 
     # input_layer = Input(shape=(max_len, num_feat))
+
     # --- Vincent Added to deal with reshaping input ---
     total_input = max_len*num_feat          # max_len~wind size and num_feat~selected columns
     input_layer = Input(shape(total_input, ))

--- a/tcn/tcn.py~
+++ b/tcn/tcn.py~
@@ -173,7 +173,7 @@ def compiled_tcn(num_feat,  # type: int
 
     # --- Vincent Added to deal with reshaping input ---
     total_input = max_len*num_feat          # max_len~wind size and num_feat~selected columns
-    input_layer = Input(shape(total_input, ))
+    input_layer = Input(shape=(total_input, ))
     reshape_layer = Reshape((max_len, num_feat, 1), input_shape=(total_input, ))(input_layer)
 
     # --- Vincent Stopped breaking stuff here ---

--- a/tcn/tcn.py~
+++ b/tcn/tcn.py~
@@ -170,7 +170,6 @@ def compiled_tcn(num_feat,  # type: int
     dilations = process_dilations(dilations)
 
     # input_layer = Input(shape=(max_len, num_feat))
-
     # --- Vincent Added to deal with reshaping input ---
     total_input = max_len*num_feat          # max_len~wind size and num_feat~selected columns
     input_layer = Input(shape(total_input, ))


### PR DESCRIPTION
This exposes Tensorflow's [`run_metadata` and `options` parameters in the `compiled_tcn()` function](https://www.tensorflow.org/api_docs/python/tf/keras/models/Model#compile) in order to allow us to profile using the Tensorflow profiling tools (see viaduct-ai/backlog#69)