### PR TITLE
Added fix for "same" padding in single output mode. Importnat for compatibility with TFLite.

### DIFF
--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -123,7 +123,8 @@ class TCN:
         if self.use_skip_connections:
             x = keras.layers.add(skip_connections)
         if not self.return_sequences:
-            x = Lambda(lambda tt: tt[:, -1, :])(x)
+            output_slice_index = int(x.get_shape().as_list()[1]/2) if self.padding == 'same' else -1
+            x = Lambda(lambda tt: tt[:, output_slice_index, :])(x)
         return x
 
 


### PR DESCRIPTION
Added fix enabling full deductive capabilities with usage of 'same' padiing in "one output" mode. 
In case of 'same' padding, slice we want to return is one at middle index of last layer. 
Otherwise neural network will not reach results comparable in quality to 'causal' padding. 

Why 'same' padding is important? 
Currently it is the only one padding in dilated convolution that is supported by TensrFlow-Lite #TFLite.