### PR TITLE
Add batch normalization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ model.fit(x, y) # Keras model.
 - `dropout_rate`: Float between 0 and 1. Fraction of the input units to drop.
 - `activation`: The activation used in the residual blocks o = activation(x + F(x)).
 - `name`: Name of the model. Useful when having multiple TCN.
+- `use_batch_norm`: Whether or not to use BatchNormalization layat on each TCN block. Notice that the original paper 
+purposed weigth normalization instead of batch normalization, but, since it's not available on keras yet, 
+BatchNormalization is a good proxy for it.
 
 ### Input shape
 


### PR DESCRIPTION
The original paper uses a weigth normalization layer. It is not available on keras. However, batch normalization is. In fact, it is already in comments on the code.

This PR allows to optionaly use BatchNorm layer as a proxy for weigth normalization.

As an advantage: it is optional, and it is still compatible with previous versions of current library

As a disadvantage, it is not weigth normalization yet