### PR TITLE
Matching TCN original paper architecture

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup
 
 setup(
-    name='keras-tcn',
+    name='keras-tcn-fork',
     version='3.0.2',
     description='Keras TCN',
     author='Philippe Remy',
     license='MIT',
     long_description_content_type='text/markdown',
     long_description=open('README.md').read(),
-    packages=['tcn'],
+    packages=['tcn-hyeche'],
     # manually install tensorflow or tensorflow-gpu
     install_requires=[
         'numpy>=1.18.1',

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup
 
 setup(
-    name='keras-tcn-fork',
+    name='keras-tcn',
     version='3.0.2',
     description='Keras TCN',
     author='Philippe Remy',
     license='MIT',
     long_description_content_type='text/markdown',
     long_description=open('README.md').read(),
-    packages=['tcn-hyeche'],
+    packages=['tcn'],
     # manually install tensorflow or tensorflow-gpu
     install_requires=[
         'numpy>=1.18.1',

--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -105,7 +105,7 @@ class ResidualBlock(Layer):
                 self._add_and_activate_layer(Activation('relu'))
                 self._add_and_activate_layer(SpatialDropout1D(rate=self.dropout_rate))
 
-            if self.nb_filters != input_shape:
+            if self.nb_filters != input_shape[-1]:
                 # 1x1 conv to match the shapes (channel dimension).
                 name = 'matching_conv1D'
                 with K.name_scope(name):
@@ -119,6 +119,7 @@ class ResidualBlock(Layer):
             else:
                 self.shape_match_conv = Lambda(lambda x: x, name='matching_identity')
 
+
             self.shape_match_conv.build(input_shape)
             self.res_output_shape = self.shape_match_conv.compute_output_shape(input_shape)
 
@@ -128,6 +129,8 @@ class ResidualBlock(Layer):
             # this is done to force Keras to add the layers in the list to self._layers
             for layer in self.layers:
                 self.__setattr__(layer.name, layer)
+            self.__setattr__(self.shape_match_conv.name, self.shape_match_conv)
+            self.__setattr__(self.final_activation.name, self.final_activation)
 
             super(ResidualBlock, self).build(input_shape)  # done to make sure self.built is set True
 

--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -186,10 +186,10 @@ class TCN(Layer):
                  nb_stacks=1,
                  dilations=(1, 2, 4, 8, 16, 32),
                  padding='causal',
-                 use_skip_connections=True,
+                 use_skip_connections=False,
                  dropout_rate=0.0,
                  return_sequences=False,
-                 activation='linear',
+                 activation='relu',
                  kernel_initializer='he_normal',
                  use_batch_norm=False,
                  use_layer_norm=False,
@@ -283,16 +283,6 @@ class TCN(Layer):
     def call(self, inputs, training=None):
         x = inputs
         self.layers_outputs = [x]
-        try:
-            x = self.main_conv1D(x)
-            self.layers_outputs.append(x)
-        except AttributeError:
-            print('The backend of keras-tcn>2.8.3 has changed from keras to tensorflow.keras.')
-            print('Either update your imports:\n- From "from keras.layers import <LayerName>" '
-                  '\n- To "from tensorflow.keras.layers import <LayerName>"')
-            print('Or downgrade to 2.8.3 by running "pip install keras-tcn==2.8.3"')
-            import sys
-            sys.exit(0)
         self.skip_connections = []
         for layer in self.residual_blocks:
             x, skip_out = layer(x, training=training)
@@ -338,13 +328,13 @@ def compiled_tcn(num_feat,  # type: int
                  max_len,  # type: int
                  output_len=1,  # type: int
                  padding='causal',  # type: str
-                 use_skip_connections=True,  # type: bool
+                 use_skip_connections=False,  # type: bool
                  return_sequences=True,
                  regression=False,  # type: bool
                  dropout_rate=0.05,  # type: float
                  name='tcn',  # type: str,
                  kernel_initializer='he_normal',  # type: str,
-                 activation='linear',  # type:str,
+                 activation='relu',  # type:str,
                  opt='adam',
                  lr=0.002,
                  use_batch_norm=False,

--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -210,7 +210,6 @@ class TCN(Layer):
         self.skip_connections = []
         self.residual_blocks = []
         self.layers_outputs = []
-        self.main_conv1D = None
         self.build_output_shape = None
         self.lambda_layer = None
         self.lambda_ouput_shape = None
@@ -235,14 +234,9 @@ class TCN(Layer):
         return self.kernel_size * self.nb_stacks * self.dilations[-1]
 
     def build(self, input_shape):
-        self.main_conv1D = Conv1D(filters=self.nb_filters,
-                                  kernel_size=1,
-                                  padding=self.padding,
-                                  kernel_initializer=self.kernel_initializer)
-        self.main_conv1D.build(input_shape)
 
         # member to hold current output shape of the layer for building purposes
-        self.build_output_shape = self.main_conv1D.compute_output_shape(input_shape)
+        self.build_output_shape = input_shape
 
         # list to hold all the member ResidualBlocks
         self.residual_blocks = []

--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -117,11 +117,12 @@ class ResidualBlock(Layer):
                                                    kernel_initializer=self.kernel_initializer)
 
             else:
-                self.shape_match_conv = Lambda(lambda x: x, name='matching_identity')
+                name = 'matching_identity'
+                self.shape_match_conv = Lambda(lambda x: x, name=name)
 
-
-            self.shape_match_conv.build(input_shape)
-            self.res_output_shape = self.shape_match_conv.compute_output_shape(input_shape)
+            with K.name_scope(name):
+                self.shape_match_conv.build(input_shape)
+                self.res_output_shape = self.shape_match_conv.compute_output_shape(input_shape)
 
             self.final_activation = Activation(self.activation)
             self.final_activation.build(self.res_output_shape)  # probably isn't necessary


### PR DESCRIPTION
In this pull request I modified in the file `tcn/tcn.py` the classes `ResidualBlock`, `TCN` and `compiled_tcn`.
- In `ResidualBlock` I modified the condition to  use a 1x1 Conv for the matching part. Indeed the condition was to not be the last block whereas in the paper the condition is to have a differents number of channels between input and output. I also added this layer to self._layers in order to make sure the variable is trainable.
- In `TCN`, I removed the first main Conv1D that is not in the original paper. In addition I set the `use_skip_connection` to `False` and `activation` to `relu` as in the paper.
- In `compiled_tcn` I just change the two above params to default

Tell me what you think of it :)
