### PR TITLE
Keras 3 conflict resolved

### DIFF
--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -315,7 +315,13 @@ class TCN(Layer):
         else:
             self.output_slice_index = -1  # causal case.
         self.slicer_layer = Lambda(lambda tt: tt[:, self.output_slice_index, :], name='Slice_Output')
-        self.slicer_layer.build(self.build_output_shape.as_list())
+
+        # In keras 3, build_output_shape is acting like a tuple, and as_list is not available. 
+        try:
+            self.slicer_layer.build(self.build_output_shape.as_list())
+        except AttributeError:
+            self.slicer_layer.build(list(self.build_output_shape))
+            
 
     def compute_output_shape(self, input_shape):
         """


### PR DESCRIPTION
The instructions from https://github.com/philipperemy/keras-tcn/issues/256#issuecomment-2062096061 applied. @Kurdakov

I have seen those errors, and found out the right way was to cast the value when runnning on a keras > 3 situation as he mentioned.

I also preferred to save the previous code with a try except block, and its working as expected.

I'm actively using this in a project, and the env is keep changing, sometimes in a colab and sometimes on my local machine, and I just don't want to spent any more time with changing library code by searching it, so that I'm going to keep my repository open until you decide to make this change and will be doing pip install with +git form my own repo for keras-tcn