### PR TITLE
Version 3.5.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = ['numpy', tensorflow]
 
 setup(
     name='keras-tcn',
-    version='3.5.5',
+    version='3.5.6',
     description='Keras TCN',
     author='Philippe Remy',
     license_files=['MIT'],

--- a/tcn/__init__.py
+++ b/tcn/__init__.py
@@ -1,3 +1,3 @@
 from tcn.tcn import TCN, compiled_tcn, tcn_full_summary  # noqa
 
-__version__ = '3.5.5'
+__version__ = '3.5.6'

--- a/tcn/tcn.py
+++ b/tcn/tcn.py
@@ -2,8 +2,13 @@ import inspect
 from typing import List  # noqa
 
 import tensorflow as tf
-# pylint: disable=E0611,E0401
-from keras.src.saving import register_keras_serializable
+try:
+    # pylint: disable=E0611,E0401
+    from keras.src.saving import register_keras_serializable  # For recent Keras
+except ImportError:
+    # pylint: disable=E0611,E0401
+    from tensorflow.keras.saving import register_keras_serializable  # For older versions
+
 # pylint: disable=E0611,E0401
 from tensorflow.keras import backend as K, Model, Input, optimizers
 # pylint: disable=E0611,E0401


### PR DESCRIPTION
Fix: No module named keras.src. https://github.com/philipperemy/keras-tcn/issues/280